### PR TITLE
feat: portal zoom transition + full-screen journal, remove bookmarks/…

### DIFF
--- a/css/journal.css
+++ b/css/journal.css
@@ -194,20 +194,24 @@ html, body {
   pointer-events: none;
 }
 
+/* ---------- Portal Flash ---------- */
+#portal-flash {
+  position: fixed;
+  inset: 0;
+  z-index: 20;        /* above journal-ui (z-index 15) */
+  background: #fff;
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* ---------- Journal Book outer shell ---------- */
-/* overflow: visible so bookmark tabs can protrude */
 #journal-book {
   position: relative;
-  width: min(76rem, 92vw);
-  height: min(88vh, 820px);
+  width: 100%;
+  height: 100%;
   pointer-events: all;
-  /* GSAP animates opacity + scale */
   opacity: 0;
   transform-origin: center center;
-
-  /* Outer shadow sits on this element */
-  filter: drop-shadow(0 24px 48px rgba(50, 25, 5, 0.32))
-          drop-shadow(0 4px 12px rgba(50, 25, 5, 0.18));
 }
 
 /* ---------- Book Paper (clipped inner area) ---------- */
@@ -216,7 +220,6 @@ html, body {
   flex-direction: row;
   width: 100%;
   height: 100%;
-  border-radius: 8px 22px 22px 8px;
   overflow: hidden;
 
   /* Aged paper texture */
@@ -416,85 +419,6 @@ html, body {
 .page-inner::-webkit-scrollbar { width: 4px; }
 .page-inner::-webkit-scrollbar-track { background: transparent; }
 .page-inner::-webkit-scrollbar-thumb { background: rgba(201, 168, 76, 0.28); border-radius: 2px; }
-
-/* Dog-ear corners */
-.page-corner-tl,
-.page-corner-tr {
-  position: absolute;
-  z-index: 3;
-  pointer-events: none;
-}
-
-.page-corner-tl {
-  top: 0; left: 0;
-  width: 26px; height: 26px;
-  background: linear-gradient(135deg, rgba(150, 110, 55, 0.15) 50%, transparent 50%);
-}
-
-.page-corner-tr {
-  top: 0; right: 0;
-  width: 26px; height: 26px;
-  background: linear-gradient(225deg, rgba(150, 110, 55, 0.15) 50%, transparent 50%);
-}
-
-/* ---------- Bookmark Tabs ---------- */
-#bookmarks {
-  position: absolute;
-  /* Align right edge of book-paper, stick out past it */
-  top: 10%;
-  right: 0;
-  transform: translateX(100%);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  z-index: 10;
-}
-
-.bookmark {
-  width: 36px;
-  height: 80px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  border-radius: 0 10px 10px 0;
-
-  /* Default: matches right-page paper */
-  background: linear-gradient(to right, #EDE0CB, #E6D5BE);
-  box-shadow: 2px 2px 8px rgba(50, 25, 5, 0.18);
-
-  font-family: var(--font-sc);
-  font-size: 0.52rem;
-  font-weight: 300;
-  letter-spacing: 0.25em;
-  text-transform: uppercase;
-  color: var(--ink-light);
-  writing-mode: vertical-rl;
-  text-orientation: mixed;
-  opacity: 0.65;
-
-  transition: opacity 0.2s, transform 0.2s, background 0.2s;
-  transform: translateX(-2px);
-}
-
-.bookmark:hover {
-  opacity: 0.9;
-  transform: translateX(2px);
-}
-
-.bookmark.active {
-  opacity: 1;
-  background: linear-gradient(to right, #FAF1E2, #F6EADA);
-  color: var(--ink);
-  transform: translateX(4px);
-  box-shadow: 3px 2px 10px rgba(50, 25, 5, 0.2);
-}
-
-/* Bookmark color accents */
-.bookmark[data-page="about"]    { border-top: 2px solid rgba(180, 140, 80, 0.5); }
-.bookmark[data-page="projects"] { border-top: 2px solid rgba(100, 140, 100, 0.45); }
-.bookmark[data-page="writing"]  { border-top: 2px solid rgba(160, 90, 100, 0.45); }
-.bookmark[data-page="doodle"]   { border-top: 2px solid rgba(100, 120, 180, 0.4); }
 
 /* ---------- Page Header ---------- */
 .page-hd {

--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
     <span class="hint-arrow">↓</span>
   </div>
 
+  <!-- Portal flash — full-screen white overlay for camera-dive transition -->
+  <div id="portal-flash"></div>
+
   <!-- Journal UI Overlay -->
   <div id="journal-ui">
     <div id="journal-book">
@@ -72,9 +75,6 @@
             <!-- PAGE: About -->
             <div class="page" id="page-about">
               <div class="page-inner">
-                <div class="page-corner-tl"></div>
-                <div class="page-corner-tr"></div>
-
                 <header class="page-hd">
                   <div class="page-chapter">Chapter I</div>
                   <h1 class="page-title">About</h1>
@@ -126,9 +126,6 @@
             <!-- PAGE: Projects -->
             <div class="page hidden" id="page-projects">
               <div class="page-inner">
-                <div class="page-corner-tl"></div>
-                <div class="page-corner-tr"></div>
-
                 <header class="page-hd">
                   <div class="page-chapter">Chapter II</div>
                   <h1 class="page-title">Projects</h1>
@@ -190,9 +187,6 @@
             <!-- PAGE: Writing -->
             <div class="page hidden" id="page-writing">
               <div class="page-inner">
-                <div class="page-corner-tl"></div>
-                <div class="page-corner-tr"></div>
-
                 <header class="page-hd">
                   <div class="page-chapter">Chapter III</div>
                   <h1 class="page-title">Writing</h1>
@@ -240,9 +234,6 @@
             <!-- PAGE: Doodle -->
             <div class="page hidden" id="page-doodle">
               <div class="page-inner doodle-page-inner">
-                <div class="page-corner-tl"></div>
-                <div class="page-corner-tr"></div>
-
                 <header class="page-hd">
                   <div class="page-chapter">Chapter IV</div>
                   <h1 class="page-title">Doodle</h1>
@@ -290,14 +281,6 @@
         </div><!-- #page-right -->
 
       </div><!-- #book-paper -->
-
-      <!-- Bookmark tabs — stick out from the right edge -->
-      <div id="bookmarks">
-        <div class="bookmark active" data-page="about">About</div>
-        <div class="bookmark" data-page="projects">Projects</div>
-        <div class="bookmark" data-page="writing">Writing</div>
-        <div class="bookmark" data-page="doodle">Doodle</div>
-      </div>
 
     </div><!-- #journal-book -->
   </div><!-- #journal-ui -->

--- a/js/journal.js
+++ b/js/journal.js
@@ -652,11 +652,6 @@ function bindEvents() {
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('wheel', onWheel, { passive: false });
 
-  // Bookmark navigation
-  document.querySelectorAll('.bookmark').forEach(el => {
-    el.addEventListener('click', () => navigateTo(el.dataset.page));
-  });
-
   // Close journal
   document.getElementById('bm-close')?.addEventListener('click', closeJournal);
 
@@ -740,39 +735,52 @@ function onWheel(e) {
 function openJournal() {
   S.journalOpen = true;
 
-  // Hide hint
   gsap.to('#hint', { opacity: 0, duration: 0.4 });
 
-  // Flip journal cover open
+  // Cover opens
   gsap.to(coverPivot.rotation, {
     z: Math.PI * 0.97,
-    duration: 1.6,
-    delay: 0.2,
+    duration: 1.6, delay: 0.2,
     ease: 'power2.inOut',
   });
 
-  // Camera sweeps from angled view to top-down
+  // Phase 1 — camera sweeps overhead
   gsap.to(camera.position, {
-    x: 0, y: 13, z: 0.8,
-    duration: 2.0,
-    ease: 'power3.inOut',
+    x: 0, y: 9, z: 0.5,
+    duration: 1.5,
+    ease: 'power2.inOut',
     onUpdate: () => camera.lookAt(0, 0, 0),
   });
 
-  // Fog up slightly so table fades back
+  // Phase 2 — camera dives down into the journal (portal zoom)
+  gsap.to(camera.position, {
+    x: 0, y: 1.5, z: 0,
+    duration: 1.0,
+    delay: 1.5,
+    ease: 'power4.in',
+    onUpdate: () => camera.lookAt(0, 0, 0),
+  });
+
   gsap.to(scene.fog, { density: 0.09, duration: 2.0 });
 
-  // Show HTML book as camera arrives overhead (canvas stays visible beneath)
-  setTimeout(() => {
-    const ui   = document.getElementById('journal-ui');
-    const book = document.getElementById('journal-book');
-    ui.classList.add('visible');
-    gsap.fromTo(book,
-      { scale: 0.92, opacity: 0 },
-      { scale: 1,    opacity: 1, duration: 0.6, ease: 'power2.out' }
-    );
-    document.getElementById('scroll-hint').classList.add('visible');
-  }, 1900);
+  // White flash fades in as camera hits the journal surface
+  gsap.to('#portal-flash', {
+    opacity: 1,
+    duration: 0.55,
+    delay: 1.85,
+    ease: 'power3.in',
+    onComplete: () => {
+      // While screen is white, swap in the HTML UI
+      const ui   = document.getElementById('journal-ui');
+      const book = document.getElementById('journal-book');
+      ui.classList.add('visible');
+      gsap.set(book, { opacity: 1, scale: 1 });
+      document.getElementById('scroll-hint').classList.add('visible');
+
+      // Fade the white flash out to reveal the paper page
+      gsap.to('#portal-flash', { opacity: 0, duration: 0.55, ease: 'power2.out' });
+    },
+  });
 }
 
 function closeJournal() {
@@ -781,36 +789,41 @@ function closeJournal() {
   document.getElementById('scroll-hint').classList.remove('visible');
   penGroup.visible = false;
 
-  // Dismiss HTML book
-  const book = document.getElementById('journal-book');
-  const ui   = document.getElementById('journal-ui');
-  gsap.to(book, {
-    scale: 0.92, opacity: 0,
-    duration: 0.45,
+  // Flash to white to mask the scene swap
+  gsap.to('#portal-flash', {
+    opacity: 1,
+    duration: 0.4,
     ease: 'power2.in',
-    onComplete: () => { ui.classList.remove('visible'); },
+    onComplete: () => {
+      const book = document.getElementById('journal-book');
+      const ui   = document.getElementById('journal-ui');
+      gsap.set(book, { opacity: 0 });
+      ui.classList.remove('visible');
+
+      // Snap camera back above the journal while screen is white
+      camera.position.set(0, 9, 0.5);
+      camera.lookAt(0, 0, 0);
+
+      // Fade out white while camera sweeps back to angled view
+      gsap.to('#portal-flash', { opacity: 0, duration: 1.0, ease: 'power2.out' });
+    },
   });
 
-  // Close cover
+  // Close cover + camera return (begin after flash completes ~0.4s)
   gsap.to(coverPivot.rotation, {
     z: 0,
-    duration: 1.5,
-    delay: 0.35,
+    duration: 1.5, delay: 0.5,
     ease: 'power2.inOut',
   });
 
-  // Camera back to original angled view
   gsap.to(camera.position, {
     x: 0, y: 5.5, z: 8,
-    duration: 2.0,
-    delay: 0.35,
+    duration: 2.0, delay: 0.4,
     ease: 'power3.inOut',
     onUpdate: () => camera.lookAt(0, 0, 0),
   });
 
-  gsap.to(scene.fog, { density: 0.055, duration: 2.0 });
-
-  // Show hint again
+  gsap.to(scene.fog, { density: 0.055, duration: 2.0, delay: 0.4 });
   setTimeout(() => gsap.to('#hint', { opacity: 0.8, duration: 0.8 }), 2400);
 }
 
@@ -825,10 +838,6 @@ function navigateTo(pageName) {
   S.flipping = true;
   const goForward = idx > S.pageIdx;
 
-  // Update bookmark highlight
-  document.querySelectorAll('.bookmark').forEach(el => {
-    el.classList.toggle('active', el.dataset.page === pageName);
-  });
 
   // Update left page chapter info
   const meta = CHAPTER_META[pageName];


### PR DESCRIPTION
…corners

Open sequence:
- Camera sweeps overhead (y=9, z=0.5) then dives straight down into the journal (y=1.5) — a "portal entry" zoom
- White flash fades in as camera hits the surface, masking the swap
- HTML journal UI appears full-screen while screen is white
- Flash fades out to reveal the clean paper page

Close sequence:
- White flash, camera snaps back overhead, HTML dismissed
- Flash fades out while camera glides back to angled view + cover closes

UI cleanup:
- #journal-book is now 100%x100% of the viewport (no fixed size)
- Removed border-radius from #book-paper (no more rounded corners)
- Removed drop-shadow filter from #journal-book
- Removed #bookmarks div and all .bookmark / .page-corner CSS
- Removed page-corner-tl / page-corner-tr elements from all pages
- Added #portal-flash div + CSS (z-index 20, full-screen white)

https://claude.ai/code/session_01R1vJW9iGuCV7HZyzhitHSJ