### PR TITLE
Make modal traffic light buttons larger on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1085,7 +1085,7 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US',{month:'short',day:'numeri
     display: flex;
     flex-direction: column;
     gap: var(--space-md);
-    overflow: hidden;
+    overflow-x: clip;
   }
   .shelf-label-link {
     color: inherit;
@@ -1116,7 +1116,7 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US',{month:'short',day:'numeri
     overflow-y: visible;
     scrollbar-width: none;
     padding-bottom: var(--space-lg);
-    padding-top: var(--space-xs);
+    padding-top: 8px;
   }
   .shelf-row::-webkit-scrollbar { display: none; }
   .shelf-item {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1268,6 +1268,8 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US',{month:'short',day:'numeri
     .garden-title { font-size: var(--text-section); }
     .shelf-item { width: 160px; }
     .frame-img { max-height: 220px; }
+    .traffic-dot { width: 20px; height: 20px; }
+    .modal-traffic { gap: 10px; }
   }
 </style>
 


### PR DESCRIPTION
Bumps the dots from 13px to 20px and increases gap from 7px to 10px
at ≤600px so they're easier to tap on small screens.

https://claude.ai/code/session_01SB2fTQehgu1RsHi4WcFJWf