### PR TITLE
fix: resolve all TECH_DEBT.md findings (Jun 2026 audit, round 2)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [
+    { "files": "*.astro", "options": { "parser": "astro" } }
+  ],
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 100
+}

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -19,12 +19,18 @@ Items are grouped by effort. Fixed items are removed from this list.
 | 8 | Removed dead `case_studies` collection from `content/config.ts` | Jun 2026 |
 | 9 | Added `featured` field to gallery schema (was silently missing) | Jun 2026 |
 | 10 | Fixed `date_published ?? date_built/written` coalescing in Card call sites | Jun 2026 |
+| 11 | Added `--color-danger` + `--color-traffic-red` tokens; replaced all hardcoded hex in MinimizeBar, CommunityGarden, index.astro | Jun 2026 |
+| 12 | Made `Timestamps` secondary props optional; removed duplicate `date_added` in `library/[slug].astro` | Jun 2026 |
+| 13 | `garden-push.sh` reads `VAULT_PATH`/`CONTENT_PATH` from env; runs `npm run check` before commit | Jun 2026 |
+| 14 | `sync-content.mjs` now syncs `now` collection; reads `VAULT_PATH` from env | Jun 2026 |
+| 15 | Created `src/config/github.ts`; both `CommunityGarden.astro` and `plant.ts` import from it | Jun 2026 |
+| 16 | Added empty-state guard (`nothing here yet`) + `.empty` style to all 5 collection pages | Jun 2026 |
 
 ---
 
 ## Architecture
 
-### 🟠 Extract inline scripts from `src/pages/index.astro` (2,175 lines)
+### 🟠 Extract inline scripts from `src/pages/index.astro` (~2,175 lines)
 **Risk:** High coupling — modal, sparkle, and filter logic share one risk surface.  
 **Fix:** Extract to `src/lib/{modal,overlay,sparkle}.ts` and import as `<script type="module">`.  
 **Start with:** The modal/tab system — it's the most self-contained chunk (~400 lines).
@@ -33,11 +39,6 @@ Items are grouped by effort. Fixed items are removed from this list.
 **Risk:** Drawing logic untestable; grid math invisible until a user reports a broken drawing.  
 **Fix:** Move pure grid functions (`idx`, `inBounds`, flood-fill, mirror) to `src/lib/pixel.ts`.  
 **Bonus:** Once extracted, add Vitest unit tests — these are pure functions.
-
-### 🟡 Shared `src/config/github.ts` for repo constants
-`REPO_OWNER`/`REPO_NAME` are read from env in both `CommunityGarden.astro` and `plant.ts`.  
-`plant.ts` hardcodes `LABEL = 'community-garden'` instead of reading the env var.  
-**Fix:** Create `src/config/github.ts` and import in both files.
 
 ### 🟡 Duplicated book-spine shadow CSS
 Near-identical 3-layer gradient `::after` in `index.astro:1302–1330` and `library/index.astro:77–87`.  
@@ -65,31 +66,6 @@ requires Astro 6. Astro 6 migration requires:
 
 ## Content Pipeline
 
-### 🟡 `garden-push.sh` — hardcoded absolute paths
-```bash
-# line 9-10
-VAULT="/Users/giannacrisha/Library/Mobile Documents/..."
-DEST="/Users/giannacrisha/projects/..."
-```
-**Fix:** Read from env vars (`VAULT_PATH`, `DEST_PATH`) with the current values as documented defaults.
-
-### 🟡 `garden-push.sh` — no frontmatter validation before sync
-A bad YAML field in Obsidian syncs fine, then fails the Vercel build.  
-You've already hit this (`makerflow.md` had `date_started` instead of `date_built`).  
-**Fix:** Run `npm run check` (or a frontmatter linter) in `garden-push.sh` before `git commit`, abort on failure.
-```bash
-npm run check || { echo "⛔ Type errors — fix before pushing"; exit 1; }
-```
-
-### 🟡 `scripts/sync-content.mjs` is missing `now`
-`npm run sync` covers `[archives, gallery, lab, library]` but not `now`.  
-`garden-push.sh` does include `now`. Two sync paths with different coverage.  
-**Fix:** Add `'now'` to `sync-content.mjs` — or delete one of the two sync scripts.
-
-### 🟡 `library/[slug].astro` — duplicate timestamp
-`Timestamps` receives `primaryDate` and `secondaryDate` both equal to `date_added` — renders the same date twice.  
-**Fix:** Drop the redundant secondary.
-
 ---
 
 ## DX & Tooling
@@ -103,13 +79,3 @@ Optional but helps catch structural issues early.
 `plant.ts` validators (`stripHtml`, hex-pixel sanitize) are the only code path that touches
 attacker-controlled input. They have no coverage.  
 **Fix:** Add `vitest`, extract the pure helpers, write ~15 lines of tests.
-
-### 🟡 Orphan brand colors bypassing tokens
-`#e5534b` (danger/heart red) hardcoded in `MinimizeBar.astro:92`, `CommunityGarden.astro:544,613`.  
-`#ff6059` hardcoded in `index.astro:682,794`.  
-**Fix:** Add `--color-danger: #e5534b` to `tokens.css`; reference via `var()`.
-
-### 🟡 Empty state handling on collection pages
-Index pages (`lab`, `archives`, `gallery`, `library`, `now`) have no `length === 0` guard.  
-An rsync failure or empty Obsidian vault would render a silent blank grid.  
-**Fix:** `{sorted.length === 0 ? <p class="empty">nothing here yet</p> : sorted.map(...)}`

--- a/garden-push.sh
+++ b/garden-push.sh
@@ -6,8 +6,8 @@
 
 set -e
 
-VAULT="/Users/giannacrisha/Library/Mobile Documents/iCloud~md~obsidian/Documents/gi-garden-vault"
-CONTENT="/Users/giannacrisha/projects/giannacrisha.github.io/src/content"
+VAULT="${VAULT_PATH:-"/Users/giannacrisha/Library/Mobile Documents/iCloud~md~obsidian/Documents/gi-garden-vault"}"
+CONTENT="${CONTENT_PATH:-"/Users/giannacrisha/projects/giannacrisha.github.io/src/content"}"
 
 echo "🌱 Syncing Obsidian → src/content..."
 
@@ -45,11 +45,14 @@ rsync -av --delete \
 echo ""
 
 # Check if there's anything to commit
-cd "/Users/giannacrisha/projects/giannacrisha.github.io"
+REPO="${CONTENT%/src/content}"
+cd "$REPO"
 if git diff --quiet && git diff --staged --quiet; then
   echo "✓ Nothing changed — already up to date."
   exit 0
 fi
+
+npm run check || { echo "⛔ Type errors — fix before pushing"; exit 1; }
 
 # Commit message: use argument or default with date
 MSG="${1:-"content: sync from Obsidian $(date '+%Y-%m-%d')"}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,10 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.2",
-        "typescript": "^5.0.0"
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": "^0.14.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
       }
     },
     "node_modules/@astrojs/check": {
@@ -2483,6 +2486,17 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2491,6 +2505,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2723,6 +2744,121 @@
       },
       "optionalDependencies": {
         "ajv": "^6.12.3"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/kit": {
@@ -3033,6 +3169,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -3323,6 +3469,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -3343,6 +3499,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3395,6 +3568,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3769,6 +3952,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/defu": {
@@ -4161,6 +4354,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4917,6 +5120,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4961,6 +5171,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.5.1",
@@ -6462,6 +6679,23 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -6528,6 +6762,21 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/prismjs": {
@@ -7050,6 +7299,23 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -7137,6 +7403,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7213,6 +7486,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -7330,6 +7617,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -7358,6 +7658,16 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/svgo": {
@@ -7407,6 +7717,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.3.tgz",
@@ -7430,6 +7747,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7953,6 +8300,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -8429,6 +8799,86 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
@@ -8767,6 +9217,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "sync": "node scripts/sync-content.mjs"
+    "sync": "node scripts/sync-content.mjs",
+    "format": "prettier --write \"src/**/*.{astro,ts,css,md}\" \"scripts/**/*.mjs\"",
+    "test": "vitest run"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.14",
@@ -22,7 +24,10 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.2",
-    "typescript": "^5.0.0"
+    "prettier": "^3.0.0",
+    "prettier-plugin-astro": "^0.14.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
   },
   "overrides": {
     "path-to-regexp": "^6.3.0"

--- a/scripts/sync-content.mjs
+++ b/scripts/sync-content.mjs
@@ -6,15 +6,19 @@
 // Drafts stay in your vault's inbox (which is gitignored anyway).
 
 import { cpSync, existsSync, mkdirSync, readdirSync } from 'fs';
-import { join, resolve } from 'path';
+import { join, resolve } from 'node:path';
 
-const VAULT = resolve(
-  '/Users/giannacrisha/Library/Mobile Documents/iCloud~md~obsidian/Documents/gi-garden-vault/🌱 garden'
+const VAULT_ROOT = resolve(
+  process.env.VAULT_PATH ?? '/Users/giannacrisha/Library/Mobile Documents/iCloud~md~obsidian/Documents/gi-garden-vault'
 );
+
+const VAULT = join(VAULT_ROOT, '🌱 garden');
 
 const REPO_CONTENT = resolve('src/content');
 
+// 'now' lives one level up from the garden folder, under '👇 now/'
 const COLLECTIONS = ['archives', 'gallery', 'lab', 'library'];
+const EXTRA = [{ name: 'now', src: join(VAULT_ROOT, '👇 now') }];
 
 let copied = 0;
 
@@ -37,6 +41,25 @@ for (const col of COLLECTIONS) {
   }
 
   console.log(`✓  ${col}: ${files.length} file${files.length === 1 ? '' : 's'}`);
+}
+
+for (const { name, src } of EXTRA) {
+  const dest = join(REPO_CONTENT, name);
+
+  if (!existsSync(src)) {
+    console.log(`⚠️  Vault folder not found, skipping: ${src}`);
+    continue;
+  }
+
+  mkdirSync(dest, { recursive: true });
+
+  const files = readdirSync(src).filter(f => f.endsWith('.md'));
+  for (const file of files) {
+    cpSync(join(src, file), join(dest, file));
+    copied++;
+  }
+
+  console.log(`✓  ${name}: ${files.length} file${files.length === 1 ? '' : 's'}`);
 }
 
 console.log(`\n✨ Synced ${copied} file${copied === 1 ? '' : 's'} total.`);

--- a/src/components/CommunityGarden.astro
+++ b/src/components/CommunityGarden.astro
@@ -1,8 +1,6 @@
 ---
 // src/components/CommunityGarden.astro
-const REPO_OWNER = import.meta.env.GITHUB_REPO_OWNER ?? 'giannacrisha';
-const REPO_NAME  = import.meta.env.GITHUB_REPO_NAME  ?? 'giannacrisha.github.io';
-const LABEL      = import.meta.env.GITHUB_GARDEN_LABEL ?? 'community-garden';
+import { REPO_OWNER, REPO_NAME, LABEL } from '../config/github';
 
 function timeAgo(dateStr: string): string {
   const now = Date.now();
@@ -522,7 +520,7 @@ const HEART_FILLED = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" view
     border-radius: 12px;
   }
   .planting:hover .heart-overlay { opacity: 1; background: rgba(0,0,0,0.38); }
-  .heart-overlay.heart-active { color: #e5534b; }
+  .heart-overlay.heart-active { color: var(--color-danger); }
   .planting:hover .heart-overlay.heart-active { background: rgba(0,0,0,0.18); }
 
   .heart-icon-empty,
@@ -591,7 +589,7 @@ const HEART_FILLED = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" view
     min-width: 10px;
     text-align: center;
   }
-  .heart-count.heart-count--active { color: #e5534b; }
+  .heart-count.heart-count--active { color: var(--color-danger); }
 
   @keyframes count-up {
     from { opacity: 0; transform: translateY(3px); }
@@ -728,8 +726,9 @@ const HEART_FILLED = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" view
 </style>
 
 <script>
+import { GRID, idx, inBounds, bresenham, rectOutline, ellipseOutline, floodFill } from '../lib/pixel';
 (function () {
-  const GRID = 16, CELL = 16;
+  const CELL = 16;
 
   // ── Canvas setup ─────────────────────────────────────────────────────
   const canvas = document.getElementById('pixel-canvas') as HTMLCanvasElement;
@@ -773,9 +772,6 @@ const HEART_FILLED = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" view
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────
-  function idx(c:number,r:number){ return r*GRID+c; }
-  function inBounds(c:number,r:number){ return c>=0&&c<GRID&&r>=0&&r<GRID; }
-
   function getColRow(e: MouseEvent|TouchEvent):{col:number,row:number} {
     const rect = canvas.getBoundingClientRect();
     let cx:number, cy:number;
@@ -796,54 +792,6 @@ const HEART_FILLED = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" view
     for (let dy=0;dy<brushSize;dy++) for (let dx=0;dx<brushSize;dx++) {
       const c=col+dx-half, r=row+dy-half;
       if (inBounds(c,r)) target[idx(c,r)]=color;
-    }
-  }
-
-  function bresenham(x0:number,y0:number,x1:number,y1:number):{col:number,row:number}[] {
-    const pts=[];
-    let dx=Math.abs(x1-x0),dy=Math.abs(y1-y0),sx=x0<x1?1:-1,sy=y0<y1?1:-1,err=dx-dy;
-    while(true){
-      pts.push({col:x0,row:y0});
-      if(x0===x1&&y0===y1)break;
-      const e2=2*err;
-      if(e2>-dy){err-=dy;x0+=sx;}
-      if(e2<dx){err+=dx;y0+=sy;}
-    }
-    return pts;
-  }
-
-  function rectOutline(x0:number,y0:number,x1:number,y1:number):{col:number,row:number}[] {
-    const pts=[];
-    const minX=Math.min(x0,x1),maxX=Math.max(x0,x1),minY=Math.min(y0,y1),maxY=Math.max(y0,y1);
-    for(let x=minX;x<=maxX;x++){pts.push({col:x,row:minY});if(minY!==maxY)pts.push({col:x,row:maxY});}
-    for(let y=minY+1;y<maxY;y++){pts.push({col:minX,row:y});if(minX!==maxX)pts.push({col:maxX,row:y});}
-    return pts;
-  }
-
-  function ellipseOutline(x0:number,y0:number,x1:number,y1:number):{col:number,row:number}[] {
-    const cx=(x0+x1)/2, cy=(y0+y1)/2, rx=Math.abs(x1-x0)/2, ry=Math.abs(y1-y0)/2;
-    if(rx<0.4&&ry<0.4) return [{col:Math.round(cx),row:Math.round(cy)}];
-    const pts=new Map<string,{col:number,row:number}>();
-    const steps=Math.ceil(Math.PI*2*Math.max(rx,ry)*2.5);
-    for(let i=0;i<steps;i++){
-      const a=(i/steps)*Math.PI*2;
-      const c=Math.round(cx+Math.cos(a)*rx), r=Math.round(cy+Math.sin(a)*ry);
-      if(inBounds(c,r)){const k=`${c},${r}`;if(!pts.has(k))pts.set(k,{col:c,row:r});}
-    }
-    return [...pts.values()];
-  }
-
-  function floodFill(col:number,row:number,newColor:string|null){
-    const si=idx(col,row), target=pixels[si];
-    if(target===newColor)return;
-    const stack=[si],visited=new Set<number>();
-    while(stack.length){
-      const i=stack.pop()!;
-      if(visited.has(i)||pixels[i]!==target)continue;
-      visited.add(i);pixels[i]=newColor;
-      const c=i%GRID,r=Math.floor(i/GRID);
-      if(c>0)stack.push(i-1);if(c<GRID-1)stack.push(i+1);
-      if(r>0)stack.push(i-GRID);if(r<GRID-1)stack.push(i+GRID);
     }
   }
 
@@ -946,7 +894,7 @@ const HEART_FILLED = `<svg xmlns="http://www.w3.org/2000/svg" height="20px" view
       redraw();
     } else if(tool==='fill'){
       pushUndo();
-      floodFill(cc,cr,currentColor); redraw(); isDown=false;
+      floodFill(pixels,cc,cr,currentColor); redraw(); isDown=false;
     } else if(tool==='line'||tool==='rect'||tool==='circle'){
       pushUndo();
       basePixels=[...pixels];

--- a/src/components/MinimizeBar.astro
+++ b/src/components/MinimizeBar.astro
@@ -89,7 +89,7 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: #e5534b;
+    background: var(--color-danger);
     border: none;
     cursor: pointer;
     display: flex;

--- a/src/components/Timestamps.astro
+++ b/src/components/Timestamps.astro
@@ -1,18 +1,22 @@
 ---
 // src/components/Timestamps.astro
 interface Props {
-  primaryLabel:   string;
-  primaryDate:    Date;
-  secondaryLabel: string;
-  secondaryDate:  Date;
+  primaryLabel:    string;
+  primaryDate:     Date;
+  secondaryLabel?: string;
+  secondaryDate?:  Date;
 }
 const { primaryLabel, primaryDate, secondaryLabel, secondaryDate } = Astro.props;
 const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 ---
 <p class="timestamps">
   <span>{primaryLabel} {fmt(primaryDate)}</span>
-  <span class="dot" aria-hidden="true"></span>
-  <span>{secondaryLabel} {fmt(secondaryDate)}</span>
+  {secondaryLabel && secondaryDate && (
+    <>
+      <span class="dot" aria-hidden="true"></span>
+      <span>{secondaryLabel} {fmt(secondaryDate)}</span>
+    </>
+  )}
 </p>
 
 <style>

--- a/src/config/github.ts
+++ b/src/config/github.ts
@@ -1,0 +1,5 @@
+// src/config/github.ts
+// Single source of truth for GitHub API constants used by CommunityGarden and plant.ts.
+export const REPO_OWNER = import.meta.env.GITHUB_REPO_OWNER ?? 'giannacrisha';
+export const REPO_NAME  = import.meta.env.GITHUB_REPO_NAME  ?? 'giannacrisha.github.io';
+export const LABEL      = import.meta.env.GITHUB_GARDEN_LABEL ?? 'community-garden';

--- a/src/lib/pixel.ts
+++ b/src/lib/pixel.ts
@@ -1,0 +1,80 @@
+// src/lib/pixel.ts
+// Pure grid math for the 16×16 pixel-art canvas in CommunityGarden.astro.
+// Extracted here so these functions are testable in isolation.
+
+export const GRID = 16;
+
+export function idx(c: number, r: number): number {
+  return r * GRID + c;
+}
+
+export function inBounds(c: number, r: number): boolean {
+  return c >= 0 && c < GRID && r >= 0 && r < GRID;
+}
+
+export function bresenham(x0: number, y0: number, x1: number, y1: number): { col: number; row: number }[] {
+  const pts: { col: number; row: number }[] = [];
+  let dx = Math.abs(x1 - x0), dy = Math.abs(y1 - y0);
+  let sx = x0 < x1 ? 1 : -1, sy = y0 < y1 ? 1 : -1;
+  let err = dx - dy;
+  while (true) {
+    pts.push({ col: x0, row: y0 });
+    if (x0 === x1 && y0 === y1) break;
+    const e2 = 2 * err;
+    if (e2 > -dy) { err -= dy; x0 += sx; }
+    if (e2 < dx)  { err += dx; y0 += sy; }
+  }
+  return pts;
+}
+
+export function rectOutline(x0: number, y0: number, x1: number, y1: number): { col: number; row: number }[] {
+  const pts: { col: number; row: number }[] = [];
+  const minX = Math.min(x0, x1), maxX = Math.max(x0, x1);
+  const minY = Math.min(y0, y1), maxY = Math.max(y0, y1);
+  for (let x = minX; x <= maxX; x++) {
+    pts.push({ col: x, row: minY });
+    if (minY !== maxY) pts.push({ col: x, row: maxY });
+  }
+  for (let y = minY + 1; y < maxY; y++) {
+    pts.push({ col: minX, row: y });
+    if (minX !== maxX) pts.push({ col: maxX, row: y });
+  }
+  return pts;
+}
+
+export function ellipseOutline(x0: number, y0: number, x1: number, y1: number): { col: number; row: number }[] {
+  const cx = (x0 + x1) / 2, cy = (y0 + y1) / 2;
+  const rx = Math.abs(x1 - x0) / 2, ry = Math.abs(y1 - y0) / 2;
+  if (rx < 0.4 && ry < 0.4) return [{ col: Math.round(cx), row: Math.round(cy) }];
+  const pts = new Map<string, { col: number; row: number }>();
+  const steps = Math.ceil(Math.PI * 2 * Math.max(rx, ry) * 2.5);
+  for (let i = 0; i < steps; i++) {
+    const a = (i / steps) * Math.PI * 2;
+    const c = Math.round(cx + Math.cos(a) * rx), r = Math.round(cy + Math.sin(a) * ry);
+    if (inBounds(c, r)) {
+      const k = `${c},${r}`;
+      if (!pts.has(k)) pts.set(k, { col: c, row: r });
+    }
+  }
+  return [...pts.values()];
+}
+
+// floodFill mutates the pixels array in place.
+export function floodFill(pixels: (string | null)[], col: number, row: number, newColor: string | null): void {
+  const si = idx(col, row);
+  const target = pixels[si];
+  if (target === newColor) return;
+  const stack = [si];
+  const visited = new Set<number>();
+  while (stack.length) {
+    const i = stack.pop()!;
+    if (visited.has(i) || pixels[i] !== target) continue;
+    visited.add(i);
+    pixels[i] = newColor;
+    const c = i % GRID, r = Math.floor(i / GRID);
+    if (c > 0)        stack.push(i - 1);
+    if (c < GRID - 1) stack.push(i + 1);
+    if (r > 0)        stack.push(i - GRID);
+    if (r < GRID - 1) stack.push(i + GRID);
+  }
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,24 @@
+// src/lib/sanitize.ts
+// Input sanitization helpers shared by plant.ts (and testable by vitest).
+
+// Valid CSS hex color: #rgb, #rrggbb, #rrggbbaa
+export const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+export function stripHtml(str: string): string {
+  return str.replace(/<[^>]*>/g, '').replace(/&(?:[a-z]+|#\d+);/gi, (e) => {
+    const map: Record<string, string> = {
+      '&amp;': '&',
+      '&lt;':  '<',
+      '&gt;':  '>',
+      '&quot;': '"',
+      '&#39;':  "'",
+    };
+    return map[e] ?? e;
+  });
+}
+
+export function sanitizePixel(p: unknown): string | null {
+  if (p === null || p === undefined) return null;
+  if (typeof p === 'string' && HEX_COLOR.test(p)) return p;
+  return null;
+}

--- a/src/pages/api/plant.ts
+++ b/src/pages/api/plant.ts
@@ -19,20 +19,8 @@ const ratelimit = new Ratelimit({
   prefix:  'rl:plant',
 });
 
-const REPO_OWNER = import.meta.env.GITHUB_REPO_OWNER ?? 'giannacrisha';
-const REPO_NAME  = import.meta.env.GITHUB_REPO_NAME  ?? 'giannacrisha.github.io';
-const LABEL      = 'community-garden';
-
-// Valid pixel color: null, or a CSS hex color (#rgb, #rrggbb, #rrggbbaa)
-const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
-
-// Strip all HTML tags from a string (defense-in-depth alongside Astro escaping)
-function stripHtml(str: string): string {
-  return str.replace(/<[^>]*>/g, '').replace(/&(?:[a-z]+|#\d+);/gi, (e) => {
-    const map: Record<string, string> = { '&amp;':'&','&lt;':'<','&gt;':'>','&quot;':'"','&#39;':"'" };
-    return map[e] ?? e;
-  });
-}
+import { REPO_OWNER, REPO_NAME, LABEL } from '../../config/github';
+import { stripHtml, sanitizePixel } from '../../lib/sanitize';
 
 export const POST: APIRoute = async ({ request }) => {
   const token = import.meta.env.GITHUB_TOKEN;
@@ -69,11 +57,7 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response(JSON.stringify({ error: 'Invalid pixel data' }), { status: 400 });
   }
   // Each pixel must be null or a valid hex color string — no arbitrary strings
-  const safePixels: (string | null)[] = pixels.map(p => {
-    if (p === null || p === undefined) return null;
-    if (typeof p === 'string' && HEX_COLOR.test(p)) return p;
-    return null; // silently drop any invalid value
-  });
+  const safePixels: (string | null)[] = pixels.map(sanitizePixel);
   const painted = safePixels.filter(Boolean).length;
   if (painted < 4) {
     return new Response(JSON.stringify({ error: 'Draw something first!' }), { status: 400 });

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -46,6 +46,7 @@ const filters = [
     </div>
     <CollectionFilters filters={filters} />
     <div class="card-grid">
+      {sorted.length === 0 && <p class="empty">nothing here yet</p>}
       {sorted.map(entry => (
         <div
           data-filter={JSON.stringify({ type: entry.data.type, stage: entry.data.growth_stage })}

--- a/src/pages/gallery/index.astro
+++ b/src/pages/gallery/index.astro
@@ -47,6 +47,7 @@ const filters = [
     </div>
     <CollectionFilters filters={filters} />
     <div class="masonry">
+      {sorted.length === 0 && <p class="empty">nothing here yet</p>}
       {sorted.map(entry => (
         <div
           class="masonry-item"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -679,7 +679,7 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US',{month:'short',day:'numeri
     padding: 0;
     transition: filter 0.15s;
   }
-  .traffic-red    { background: #ff6059; cursor: pointer; }
+  .traffic-red    { background: var(--color-traffic-red); cursor: pointer; }
   .traffic-yellow { background: #ffbd2e; cursor: pointer; }
   .traffic-green  { background: #28c841; cursor: pointer; }
   .traffic-icon {
@@ -791,7 +791,7 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US',{month:'short',day:'numeri
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: #ff6059;
+    background: var(--color-traffic-red);
     border: none;
     cursor: pointer;
     display: flex;

--- a/src/pages/lab/index.astro
+++ b/src/pages/lab/index.astro
@@ -36,6 +36,7 @@ const filters = [
     </div>
     <CollectionFilters filters={filters} />
     <div class="card-grid">
+      {sorted.length === 0 && <p class="empty">nothing here yet</p>}
       {sorted.map(entry => (
         <div
           data-filter={JSON.stringify({ stage: entry.data.growth_stage })}

--- a/src/pages/library/[slug].astro
+++ b/src/pages/library/[slug].astro
@@ -52,8 +52,6 @@ const related = allEntries
             <Timestamps
               primaryLabel="added"
               primaryDate={date_added}
-              secondaryLabel="added"
-              secondaryDate={date_added}
             />
           </div>
         </div>

--- a/src/pages/library/index.astro
+++ b/src/pages/library/index.astro
@@ -16,6 +16,7 @@ const sorted = entries.sort((a, b) => b.data.date_added.getTime() - a.data.date_
       <p class="page-def">books, films, albums, and shows worth keeping.</p>
     </div>
     <div class="book-grid">
+      {sorted.length === 0 && <p class="empty">nothing here yet</p>}
       {sorted.map(entry => {
         const d = entry.data;
         return (

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -30,6 +30,7 @@ function toISO(d: Date): string {
       </header>
 
       <div class="now-timeline">
+        {entries.length === 0 && <p class="empty">nothing here yet</p>}
         {await Promise.all(entries.map(async (entry) => {
           const { Content } = await entry.render();
           return (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -344,3 +344,10 @@ ul, ol {
 @media (max-width: 600px) {
   .card-grid { grid-template-columns: 1fr; }
 }
+
+.empty {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  padding: var(--space-xxl) 0;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -15,6 +15,8 @@
   --color-pill-bg:      #E8DDD0;
   --color-pill-text:    #6B5C47;
   --color-accent-border:#C4B49A;
+  --color-danger:       #e5534b;
+  --color-traffic-red:  #ff6059;
 
   --font-display: 'Jacquard 12', monospace;
   --font-serif:   'Lora', serif;
@@ -111,4 +113,6 @@
   --color-pill-text:    #c8b898;
   --color-accent-border:#4a4840;
   --color-surface:      #242424;
+  --color-danger:       #e5534b;
+  --color-traffic-red:  #ff6059;
 }


### PR DESCRIPTION
## Summary

Clears every open item from the June 2026 audit that was scoped to round 2 (lower-priority / content-pipeline / DX findings). `npm run check` passes with 0 errors.

### Content pipeline
- **`garden-push.sh`** — reads `VAULT_PATH` / `CONTENT_PATH` from env (existing paths as defaults); runs `npm run check` before `git commit`, aborts on failure so a bad YAML field never reaches Vercel
- **`sync-content.mjs`** — adds the `now` collection (was silently missing); reads `VAULT_PATH` from env

### Tokens & colours
- **`tokens.css`** — adds `--color-danger: #e5534b` and `--color-traffic-red: #ff6059` to both light and dark `:root`
- `MinimizeBar.astro`, `CommunityGarden.astro`, `index.astro` — all 5 hardcoded hex instances replaced with `var()`

### Components
- **`Timestamps.astro`** — `secondaryLabel` / `secondaryDate` made optional with conditional rendering (the secondary span only renders when both are provided)
- **`library/[slug].astro`** — removed duplicate `date_added` that was being passed as both primary and secondary date, rendering the same date twice

### Architecture
- **`src/config/github.ts`** — new shared module; both `CommunityGarden.astro` and `plant.ts` import `REPO_OWNER`, `REPO_NAME`, `LABEL` from it. Fixes the hardcoded `LABEL = 'community-garden'` in `plant.ts`
- **`src/lib/pixel.ts`** — extracts pure grid functions (`idx`, `inBounds`, `bresenham`, `rectOutline`, `ellipseOutline`, `floodFill`) out of `CommunityGarden.astro` — now testable in isolation. `floodFill` signature changed to take `pixels` as first arg
- **`src/lib/sanitize.ts`** — extracts `stripHtml` + a new `sanitizePixel` helper out of `plant.ts`

### DX
- **`package.json`** — adds `prettier`, `prettier-plugin-astro`, `vitest` as dev deps; adds `"format"` and `"test"` scripts
- **`.prettierrc`** — Prettier config with astro plugin, single quotes, print width 100
- **`global.css`** — adds `.empty` style used by all collection empty-state guards

### Empty states
All 5 collection pages (`lab`, `archives`, `gallery`, `library`, `now`) now show **"nothing here yet"** if the collection is empty — prevents a silent blank grid after an rsync failure or empty vault.

## Test plan

- [ ] `npm run check` → 0 errors
- [ ] `npm run build` → clean build (no new warnings)
- [ ] Visit `/lab`, `/archives`, `/gallery`, `/library`, `/now` — content renders as before
- [ ] Visit a library entry — single timestamp shown (no duplicate date)
- [ ] Community garden canvas draws, flood-fill works, hearts work
- [ ] `garden-push.sh` — run with a valid vault path; verify it runs `check` before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)