### PR TITLE
feat: community garden improvements

### DIFF
--- a/src/components/CommunityGarden.astro
+++ b/src/components/CommunityGarden.astro
@@ -232,6 +232,14 @@ const HEART_FILLED = `<svg viewBox="0 0 24 24" width="20" height="20" fill="curr
 
 </div>
 
+<!-- ── Submit success modal ──────────────────────────────────── -->
+<div id="cg-modal" class="cg-modal" aria-modal="true" role="dialog" aria-label="Submission confirmed" hidden>
+  <div class="cg-modal-card">
+    <p class="cg-modal-headline">you're in the garden ♡</p>
+    <p class="cg-modal-sub">your submission will be live soon!</p>
+  </div>
+</div>
+
 <style>
   /* ── Full-height split layout ───────────────────────── */
   .cg-layout {
@@ -609,7 +617,8 @@ const HEART_FILLED = `<svg viewBox="0 0 24 24" width="20" height="20" fill="curr
   .cg-locked {
     position: relative;
     overflow: hidden;
-    max-height: 180px;
+    max-height: 320px;
+    min-height: 280px;
   }
   .plantings-peek {
     opacity: 0.35;
@@ -725,6 +734,55 @@ const HEART_FILLED = `<svg viewBox="0 0 24 24" width="20" height="20" fill="curr
     .cg-left { border-top: var(--border); }
     .cg-right { min-height: 100vh; }
     .cg-section-divider { display: block; }
+  }
+
+  /* ── Submit success modal ────────────────────────────────── */
+  .cg-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    pointer-events: none;
+  }
+  .cg-modal[hidden] { display: none; }
+  .cg-modal-card {
+    background: var(--color-bg);
+    border: 0.5px solid var(--color-border);
+    border-radius: var(--radius-card);
+    padding: var(--space-xxl) var(--space-section);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-sm);
+    text-align: center;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.08);
+    animation: modal-in 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  }
+  .cg-modal.modal-out .cg-modal-card {
+    animation: modal-out 0.25s ease-in forwards;
+  }
+  @keyframes modal-in {
+    from { opacity: 0; transform: scale(0.88) translateY(8px); }
+    to   { opacity: 1; transform: scale(1)    translateY(0);   }
+  }
+  @keyframes modal-out {
+    from { opacity: 1; transform: scale(1)    translateY(0);   }
+    to   { opacity: 0; transform: scale(0.94) translateY(-6px); }
+  }
+  .cg-modal-headline {
+    font-family: var(--font-body);
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--color-fg);
+    margin: 0;
+  }
+  .cg-modal-sub {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--color-muted);
+    margin: 0;
   }
 </style>
 
@@ -1165,6 +1223,14 @@ import { GRID, idx, inBounds, bresenham, rectOutline, ellipseOutline, floodFill 
       unlockGarden();
       form.style.opacity='0'; form.style.transition='opacity 0.2s';
       setTimeout(()=>{form.style.display='none';confirm2.removeAttribute('hidden');},200);
+      // Flash success modal
+      const modal = document.getElementById('cg-modal')!;
+      modal.removeAttribute('hidden');
+      modal.classList.remove('modal-out');
+      setTimeout(() => {
+        modal.classList.add('modal-out');
+        setTimeout(() => modal.setAttribute('hidden', ''), 260);
+      }, 2800);
     } catch(err:any){
       errorEl.textContent=err.message; errorEl.removeAttribute('hidden');
       plantBtn.disabled=false; plantBtn.textContent='plant';

--- a/src/pages/api/heart.ts
+++ b/src/pages/api/heart.ts
@@ -7,17 +7,14 @@ import type { APIRoute } from 'astro';
 import { Redis } from '@upstash/redis';
 import { Ratelimit } from '@upstash/ratelimit';
 
-const redis = new Redis({
-  url:   import.meta.env.KV_REST_API_URL,
-  token: import.meta.env.KV_REST_API_TOKEN,
-});
+const kvUrl   = import.meta.env.KV_REST_API_URL;
+const kvToken = import.meta.env.KV_REST_API_TOKEN;
+const redis = kvUrl && kvToken ? new Redis({ url: kvUrl, token: kvToken }) : null;
 
 // Sliding window: 30 heart actions per IP per 60 seconds, shared across all instances.
-const ratelimit = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(30, '60 s'),
-  prefix:  'rl:heart',
-});
+const ratelimit = redis
+  ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(30, '60 s'), prefix: 'rl:heart' })
+  : null;
 
 export const POST: APIRoute = async ({ request }) => {
   // Prefer Vercel's trusted header over spoofable x-forwarded-for first-hop.
@@ -26,9 +23,11 @@ export const POST: APIRoute = async ({ request }) => {
           ?? request.headers.get('x-real-ip')
           ?? 'unknown';
 
-  const { success } = await ratelimit.limit(ip);
-  if (!success) {
-    return new Response(JSON.stringify({ error: 'Too many requests.' }), { status: 429 });
+  if (ratelimit) {
+    const { success } = await ratelimit.limit(ip);
+    if (!success) {
+      return new Response(JSON.stringify({ error: 'Too many requests.' }), { status: 429 });
+    }
   }
 
   let body: { issueNumber?: unknown; action?: unknown };
@@ -41,6 +40,10 @@ export const POST: APIRoute = async ({ request }) => {
   }
   if (action !== 'like' && action !== 'unlike') {
     return new Response(JSON.stringify({ error: 'Invalid action' }), { status: 400 });
+  }
+
+  if (!redis) {
+    return new Response(JSON.stringify({ ok: true, count: 0 }), { status: 200 });
   }
 
   const key = `hearts:${issueNumber}`;

--- a/src/pages/api/hearts.ts
+++ b/src/pages/api/hearts.ts
@@ -6,10 +6,9 @@ export const prerender = false;
 import type { APIRoute } from 'astro';
 import { Redis } from '@upstash/redis';
 
-const redis = new Redis({
-  url:   import.meta.env.KV_REST_API_URL,
-  token: import.meta.env.KV_REST_API_TOKEN,
-});
+const kvUrl   = import.meta.env.KV_REST_API_URL;
+const kvToken = import.meta.env.KV_REST_API_TOKEN;
+const redis = kvUrl && kvToken ? new Redis({ url: kvUrl, token: kvToken }) : null;
 
 export const GET: APIRoute = async ({ url }) => {
   const param = url.searchParams.get('issues') ?? '';
@@ -21,6 +20,12 @@ export const GET: APIRoute = async ({ url }) => {
 
   if (!issueNumbers.length) {
     return new Response(JSON.stringify({}), { status: 200 });
+  }
+
+  if (!redis) {
+    const counts: Record<number, number> = {};
+    issueNumbers.forEach(n => { counts[n] = 0; });
+    return new Response(JSON.stringify(counts), { status: 200, headers: { 'Cache-Control': 'no-store' } });
   }
 
   const keys    = issueNumbers.map(n => `hearts:${n}`);

--- a/src/pages/api/plant.ts
+++ b/src/pages/api/plant.ts
@@ -7,17 +7,18 @@ import type { APIRoute } from 'astro';
 import { Redis } from '@upstash/redis';
 import { Ratelimit } from '@upstash/ratelimit';
 
-const redis = new Redis({
-  url:   import.meta.env.KV_REST_API_URL,
-  token: import.meta.env.KV_REST_API_TOKEN,
-});
+const kvUrl   = import.meta.env.KV_REST_API_URL;
+const kvToken = import.meta.env.KV_REST_API_TOKEN;
+const redisConfigured = kvUrl && kvToken;
+
+const redis = redisConfigured
+  ? new Redis({ url: kvUrl, token: kvToken })
+  : null;
 
 // Sliding window: 3 plantings per IP per 10 minutes, shared across all instances.
-const ratelimit = new Ratelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(3, '600 s'),
-  prefix:  'rl:plant',
-});
+const ratelimit = redis
+  ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(3, '600 s'), prefix: 'rl:plant' })
+  : null;
 
 import { REPO_OWNER, REPO_NAME, LABEL } from '../../config/github';
 import { stripHtml, sanitizePixel } from '../../lib/sanitize';
@@ -33,9 +34,11 @@ export const POST: APIRoute = async ({ request }) => {
           ?? request.headers.get('x-forwarded-for')?.split(',')[0].trim()
           ?? request.headers.get('x-real-ip')
           ?? 'unknown';
-  const { success } = await ratelimit.limit(ip);
-  if (!success) {
-    return new Response(JSON.stringify({ error: 'Too many plantings — try again later.' }), { status: 429 });
+  if (ratelimit) {
+    const { success } = await ratelimit.limit(ip);
+    if (!success) {
+      return new Response(JSON.stringify({ error: 'Too many plantings — try again later.' }), { status: 429 });
+    }
   }
 
   let body: { pixels?: unknown[]; name?: string; note?: string; website?: string; hp?: string };

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,5 +1,7 @@
 ---
 // src/pages/community.astro
+// SSR so every visit fetches fresh submissions from GitHub Issues
+export const prerender = false;
 import Garden from '../layouts/Garden.astro';
 import CommunityGarden from '../components/CommunityGarden.astro';
 ---


### PR DESCRIPTION
## Summary

- **Submit modal** — after planting, a centered modal pops in with "you're in the garden ♡ / your submission will be live soon!" and auto-dismisses after ~3s
- **SSR fix for missing art** — community page was statically pre-rendered at build time, so new GitHub Issues submissions only appeared after a Vercel redeploy; added `export const prerender = false` to render fresh on every request
- **Dev environment fix** — Upstash Redis was instantiated unconditionally at module load, causing `Failed to parse URL from /pipeline` crashes when `KV_REST_API_URL` is not set locally; all three API routes now guard Redis init behind an env var check
- **Locked preview** — increased locked plantings section `min-height` to 280px so the blurred art is actually visible above the fade overlay (was 116px content getting swallowed by a 175px overlay)

## Test plan

- [ ] Visit `/community` and confirm all current GitHub Issues submissions are visible
- [ ] Draw something and submit — success modal should flash then fade out
- [ ] Confirm `/api/hearts`, `/api/heart`, `/api/plant` work locally without KV env vars (no more `/pipeline` error)
- [ ] Confirm locked section shows blurred plantings above the "draw something" overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)